### PR TITLE
Use Cooldown Coordinator to notify other transfer mods of cooldowns.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,15 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+
+	// for Cooldown Coordinator
+	maven {
+		url "https://maven.pkg.github.com/gniftygnome/cooldown-coordinator"
+		credentials {
+			username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
+			password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+		}
+	}
 }
 
 dependencies {
@@ -26,6 +35,9 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	// Coordinate item movement cooldowns with other mods
+    modImplementation "net.gnomecraft:cooldown-coordinator:${project.cooldowncoordinator_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,9 @@ repositories {
 
 	// for Cooldown Coordinator
 	maven {
-		url "https://maven.pkg.github.com/gniftygnome/cooldown-coordinator"
-		credentials {
-			username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-			password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+		url "https://www.cursemaven.com"
+		content {
+			includeGroup "curse.maven"
 		}
 	}
 }
@@ -36,8 +35,8 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// Coordinate item movement cooldowns with other mods
-    modImplementation "net.gnomecraft:cooldown-coordinator:${project.cooldowncoordinator_version}"
+	// Include Cooldown Coordinator 0.2.1 via cursemaven
+	include(modImplementation("curse.maven:cooldown-coordinator-594072:3697367"))
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// Include Cooldown Coordinator 0.2.1 via cursemaven
-	include(modImplementation("curse.maven:cooldown-coordinator-594072:3697367"))
+	// Include Cooldown Coordinator 0.3.0 via cursemaven
+	include(modImplementation("curse.maven:cooldown-coordinator-594072:3757479"))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	fabric_version=0.47.8+1.18.2
+    cooldowncoordinator_version=0.2.1


### PR DESCRIPTION
This PR would merge changes to use my Cooldown Coordinator mod and notify other mods when pushing items to their block entities so they can set their own item movement cooldown.  This is necessary in order for heterogeneous networks of item-transferring blocks to move items with the same timings as the vanilla Item Hopper.  For example, if OmniHopper is used in an item sorting system along with vanilla Hoppers, without Cooldown Coordinator the sorter may not work as intended.

On the downside, although I think what Cooldown Coordinator does should eventually be part of Fabric API, at this time it is not and your mod would need to depend on or JiJ the Cooldown Coordinator mod.  My [Ductwork](https://github.com/gniftygnome/ductwork) mod takes the former approach.  I have extensively tested Cooldown Coordinator and when using it the mods I have tested (which now include yours) behave as expected.

Cooldown Coordinator also patches vanilla Hoppers to implement the notification interface and notify other blocks implementing the notification interface.  This generally includes "for free" descendants of the HopperBlockEntity, such as Hopper+ and Golden Hoppers unless they override the innermost transfer method.

Although it works quite well so far, Cooldown Coordinator is basically an attempt to get a better idea what a Fabric API for this should look like.  I intend to maintain the mod until something better comes along.  Even if you are not interested in merging this PR -- and I promise that won't hurt my feelings :) -- I would love any feedback you have about the mod and what I am trying to do with it.